### PR TITLE
A more efficient and accurate memento and archive counts

### DIFF
--- a/bundledApps/WAIL.py
+++ b/bundledApps/WAIL.py
@@ -384,12 +384,12 @@ class WAILGUIFrame_Basic(wx.Panel):
     def fetchMementos(self):
         # TODO: Use CDXJ for counting the mementos
         currentURIValue = self.uri.GetValue()
+        print('MEMGATOR checking {0}'.format(currentURIValue))
         out = check_output([memGatorPath, "-a", archivesJSON,
                             '--restimeout', '0m3s',
                             '--hdrtimeout', '3s',
                             '--contimeout', '3s',
                             currentURIValue])
-        print('MEMGATOR checking {0}'.format(currentURIValue))
         
         # TODO: bug, on Gogo internet MemGator cannot hit aggregator, which
         # results in 0 mementos, for which MemGator throws exception


### PR DESCRIPTION
This PR fixes #283 and improves #282 implementation.

By processing the output stream of `Popen` as it arrives we avoid having a large TM in memory as a string. It combines the process of counting mementos and archives in a single pass. Using a set for counting archives we eliminate the need of manually checking for existence of a key.

Note: The code is not tested as I don't have proper environment setup on my machine.