### PR TITLE
Fix plurality issue, start ui count tests.

### DIFF
--- a/bundledApps/WAIL.py
+++ b/bundledApps/WAIL.py
@@ -192,25 +192,32 @@ class WAILGUIFrame_Basic(wx.Panel):
             self.mementoStatus.Destroy()
             self.mementoStatusPublicArchives.Destroy()
 
+        # Ensure mCount is an int, convert if not, allow None
+        if mCount is not None and not isinstance(mCount, int):
+            mCount = int(mCount)
+        if mCount is not None and (mCount < 0 or aCount < 0):
+            raise ValueError('Invalid memento or archive count specified')
+
         memCountMsg = ''
         if mCount is None:
             memCountMsg = config.msg_fetchingMementos
         elif mCount > 0:
             locale.setlocale(locale.LC_ALL, '')
 
-            mCount = locale.format("%d", mCount, grouping=True)
             mPlurality = 's'
             aPlurality = 's'
+
             if mCount == 1:
                 mPlurality = ''
             if aCount == 1:
                 aPlurality = ''
+            mCount = locale.format("%d", mCount, grouping=True)
             memCountMsg = ('{0} memento{1} available '
                            'from {2} archive{3}').format(
                 mCount, mPlurality, aCount, aPlurality
             )
         elif mCount == 0:
-            memCountMsg = "No mementos available."
+            memCountMsg = config.msg_noMementosAvailable
         else:
             ''' '''
 

--- a/bundledApps/WAILConfig.py
+++ b/bundledApps/WAILConfig.py
@@ -48,6 +48,7 @@ msg_wrongLocation_body = (
 msg_wrongLocation_title = "Wrong Location"
 msg_noJavaRuntime = b"No Java runtime present, requesting install."
 msg_fetchingMementos = "Fetching memento count..."
+msg_noMementosAvailable = "No mementos available."
 
 msg_crawlStatus_writingConfig = 'Writing Crawl Configuration...'
 msg_crawlStatus_launchingCrawler = 'Launching Crawler...'

--- a/test_ui_memgator.py
+++ b/test_ui_memgator.py
@@ -1,0 +1,44 @@
+# Lack of relative imports prevents this from running from tests/
+
+import wx
+import sys
+from bundledApps.WAIL import WAILGUIFrame_Basic as basic
+from bundledApps import WAILConfig as config
+
+
+class Test(wx.Frame):
+    def __init__(self, mCount, aCount):
+        wx.Frame.__init__(self, None)
+        panel = wx.Panel(self)
+        self.Notebook = wx.Notebook(panel)
+        b = basic(self.Notebook)
+        b.setMementoCount(mCount, aCount)
+        self.result = b.mementoStatus.GetLabel()
+
+
+testCases = [
+    [0, 0, config.msg_noMementosAvailable],
+    [0, 1, config.msg_noMementosAvailable],
+    [1, 0, "1 memento available from 0 archives"],
+    [1, 1, "1 memento available from 1 archive"],
+    [2, 1, "2 mementos available from 1 archive"],
+    [1, 2, "1 memento available from 2 archives"],
+    [2, 2, "2 mementos available from 2 archives"],
+    [-1, 0, ValueError()],
+    [0, -1, ValueError()],
+    [-1, -1, ValueError()]
+]
+
+for case in testCases:
+    [mCount, aCount, expectedValue] = case
+    app = wx.App()
+    try:
+        mainAppWindow = Test(mCount, aCount)
+        res = mainAppWindow.result
+        testPass = (res == expectedValue)
+        assert testPass
+    except ValueError:
+        assert type(expectedValue) is type(ValueError())
+    app.Destroy()
+
+


### PR DESCRIPTION
#295 was re-opened due to the issue of a single memento/archive being queried resulted in a plural despite conditions to check for this. The issue stemmed from changing the locale, which caused a conversion to a string, which did not meet the integer-based condition. Fixed this and wrote a preliminary test series to evaluate the resultant UI message. Also added negative value handling for #315.

Closes #295...again.

An issue remains in the relative import of the new test file. Because WAIL is not installed as a module, the standard test procedure cannot find bundledApps/WAIL.py from /test/testName.py.

Running the test file from the root via simple python execution works for now but is insufficient for automated testing. It's a start for #315 but does not quite yet meet the requirement to close the ticket.