### PR TITLE
Change string conversion of status checks in UI for

### DIFF
--- a/bundledApps/WAIL.py
+++ b/bundledApps/WAIL.py
@@ -927,10 +927,10 @@ class WAILGUIFrame_Advanced(wx.Panel):
 
             # Update a transitional status and short circuit
             if serviceId and transitionalStatus:
-                if serviceId is "wayback":
+                if serviceId == "wayback":
                     self.setWaybackStatus(transitionalStatus)
                     return
-                elif serviceId is "heritrix":
+                elif serviceId == "heritrix":
                     self.setHeritrixStatus(transitionalStatus)
                     return
                 else:


### PR DESCRIPTION
services from python "is" to == for Py 3.8.

Related to #443