### PR TITLE
Check if Travis supports Py 3.8 for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       python: 3.8           # this works for Linux but is ignored on macOS or Windows
     - name: "Python 3.7 on macOS"
       os: osx
-      osx_image: xcode11.2  # Python 3.7.5 running on macOS 10.14.4
+      osx_image: xcode12.2  # Python 3.7.5 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
     - name: "Python 3.8 on Windows"
       os: windows


### PR DESCRIPTION
Answer: Not yet, but this updates the build of macOS used.