### PR TITLE
Fix issue of symbols not displaying in the Linux interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN        apt update && apt install -y \
              x11vnc \
              xvfb \
              language-pack-en \
+             ttf-ancient-fonts \
        &&  rm -rf /var/lib/apt/lists/*
 
 RUN        pip3 install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04 wxPython==4.1.1 \


### PR DESCRIPTION
The symbols would not display in the status bar due to missing
fonts by default in the Docker container. This fix adds the
dependency described in #505

Fixes #505