### PR TITLE
Fix context menu on renamed Heritrix jobs

### DIFF
--- a/bundledApps/wailUtil.py
+++ b/bundledApps/wailUtil.py
@@ -6,7 +6,7 @@ import sys
 
 def tail(filename, lines=1, _buffer=4098):
     try:
-        f = open(filename, "r")
+        f = open(filename, "r", encoding="utf-8")
     except IOError as e:
         return (
             "No job info yet\n"


### PR DESCRIPTION
This was causing an exception from attempting to read the crawl
log file without explicitly indicating an encoding, which causes
Python to convert the file.

Closes #527